### PR TITLE
Standardised indentations and fixed some tag pairings 

### DIFF
--- a/events/isc-spring-2019-agenda.md
+++ b/events/isc-spring-2019-agenda.md
@@ -5,6 +5,7 @@ title: 'InnerSource Commons Spring Summit 2019 Agenda'
 [[Return to the Spring Summit 2019 page](/events/isc-spring-2019/)]
 
 
+
 <table class="schedule">
     <tr>
         <td colspan="3">
@@ -189,7 +190,7 @@ One of the main questions that any company willing to try InnerSource is how thi
     </tr>
 
 
-   <tr>
+    <tr>
         <td class="time">11:30 - 12:00</td>
         <td class="author"><a href="/events/isc-spring-2019-speakers#olivier_liechti">Olivier Liechti</a> <span class="affiliation">(Avalia Systems)</span></td>
         <td class="title"> Agile transformation at Softplan: guiding teams with data-driven experiments
@@ -207,7 +208,7 @@ How do you bring a legacy Enterprise Resource Planning (ERP) to "The Cloud", wit
 
     <tr>
         <td class="time">13:05 - 14:30</td>
-        <td class="author"><a href="/events/isc-spring-2019-speakers">Kristoff Van Tomme</a> <span class="affiliation">(Provonix)</span>
+        <td class="author"><a href="/events/isc-spring-2019-speakers">Kristoff Van Tomme</a> <span class="affiliation">(Provonix)</span></td>
         <td class="title"> Workshop: Dealing with common InnerSource Issues through Developer Portals
             <span onClick="toggleAbstract('van_tomme-1')" class="abstract-toggle">(<a id="van_tomme-1-link">Show Abstract</a>)</span>
             <div style="display:none" class="abstract" id="van_tomme-1">
@@ -239,14 +240,14 @@ Over the last 10 years, Red Hat Consulting has offered services around open sour
             <span onClick="toggleAbstract('newman-1')" class="abstract-toggle">(<a id="newman-1-link">Show Abstract</a>)</span>
             <div style="display:none" class="abstract" id="newman-1">
 An informal, but hopefully informative, presentation on the challenges of implementing InnerSource at a medium-sized, non-technical company. Harvard Business Publishing’s mission is to improve the practice of management in a changing world, and our areas of focus are in publishing and learning pedagogies. We thoughtfully recognize that while we are not a “technology” company, we treat software engineering as a core competency that can make or break our strategy. Adopting InnerSource was seen as a key component in our long term plans but fell far short of our expectations. We’d like to share our experience not as an any inherent indictment of InnerSource but as cautionary tale of intent and aspiration versus every day and unexciting, but very real, constraints. 
-        </div>
+            </div>
         </td>
     </tr>
 
     <tr>
         <td class="time">16:15 - 16:45</td>
-        <td class="author"><a href="/events/isc-spring-2019-speakers#max_campraro"> Max Capraro <br>
-            <a href="/events/isc-spring-2019-speakers#johannes_tigges">Johannes Tigges
+        <td class="author"><a href="/events/isc-spring-2019-speakers#max_campraro"> Max Capraro</a><br/>
+            <a href="/events/isc-spring-2019-speakers#johannes_tigges">Johannes Tigges</a>
         </td>
         <td class="title"> The Inner Source Learning Path
             <span onClick="toggleAbstract('campraro-1')" class="abstract-toggle">(<a id="campraro-1-link">Show Abstract</a>)</span>
@@ -266,6 +267,7 @@ Inner source is the application of open source methodologies to internally-devel
         <td colspan="2">Social Event</td>
     </tr>
 </table>    
+
 
 <table class="schedule">
     <tr>
@@ -324,7 +326,7 @@ Details appearing shortly
         <td colspan="2">Lunch</td>
     </tr>
 
-   <tr>
+    <tr>
         <td class="time">13:00 - 13:45</td>    
         <td class="author"><a href="/events/isc-spring-2019-speakers">Kristoff Van Tomme </a><span class="affiliation">(Provonix)</span></td>
         <td class="title">7 cultural insights to help you reinvent your organization            
@@ -335,7 +337,7 @@ Culture is hard to describe, and even harder to emulate. So how do you even star
         </td>
     </tr>
 
-   <tr>
+    <tr>
         <td class="time">13:50 - 14:30</td>
         <td class="author"><a href="/events/isc-spring-2019-speakers#danese_cooper">Danese Cooper</a></td>
         <td class="title">Governance Meeting

--- a/events/isc-spring-2019-agenda.md
+++ b/events/isc-spring-2019-agenda.md
@@ -4,6 +4,7 @@ title: 'InnerSource Commons Spring Summit 2019 Agenda'
 ---
 [[Return to the Spring Summit 2019 page](/events/isc-spring-2019/)]
 
+
 <table class="schedule">
     <tr>
         <td colspan="3">
@@ -21,39 +22,39 @@ title: 'InnerSource Commons Spring Summit 2019 Agenda'
 
    <tr>
         <td class="time">09:20 - 10:20</td>
-         <td class="author">
+        <td class="author">
             <a href="/events/isc-spring-2019-speakers#john_landy">John Landy</a><span class="affiliation"> (Ericsson)
             </span><br/>
-        <a href="/events/isc-spring-2019-speakers#eoin_conneely">Eoin Conneelly</a><span class="affiliation"> (Ericsson)</span>
+        <a href="/events/isc-spring-2019-speakers#eoin_conneely">Eoin Conneelly</a><span class="affiliation"> (Ericsson)</span></td>
 
-   <td class="title">
-            <span class="keynoteTag">Keynote:</span></span>
-                <span onClick="toggleAbstract('keynote-landy')" class="abstract-toggle">(<a id="keynote-landy-link">Show Abstract</a>)</span>
-       <div style="display:none" class="abstract" id="keynote-landy">
+        <td class="title">
+            <span class="keynoteTag">Keynote:</span>
+            <span onClick="toggleAbstract('keynote-landy')" class="abstract-toggle">(<a id="keynote-landy-link">Show Abstract</a>)</span>
+        <div style="display:none" class="abstract" id="keynote-landy">
 Details appearing shortly 
-</div>
+        </div>
         </td>
     </tr>
   
- <tr >
+    <tr>
         <td class="time">10:25 - 10:55</td>
         <td colspan="2">Coffee Break</td>
     </tr>
 
-  <tr>
+    <tr>
         <td class="time">11:00 - 11:30</td>
         <td class="author">
-<a href="/events/isc-spring-2019-speakers#georg_gruetter">Georg Gruetter</a> <span class="affiliation">(Robert Bosch)</span></td>
+            <a href="/events/isc-spring-2019-speakers#georg_gruetter">Georg Gruetter</a> <span class="affiliation">(Robert Bosch)</span></td>
 
-<td class="title">A Decade of InnerSource at Bosch
-<span onClick="toggleAbstract('gruetter-1')" class="abstract-toggle">(<a id="gruetter-1-link">Show Abstract</a>)</span>
-<div style="display:none" class="abstract" id="gruetter-1">
+        <td class="title">A Decade of InnerSource at Bosch
+            <span onClick="toggleAbstract('gruetter-1')" class="abstract-toggle">(<a id="gruetter-1-link">Show Abstract</a>)</span>
+            <div style="display:none" class="abstract" id="gruetter-1">
 I will share the story of InnerSource at Bosch, which started about a decade ago. In my talk, I will share interesting details about the beginnings and the evolution of InnerSource at Bosch as well as many lessons that we learned along the way.
-    </div>
+            </div>
         </td>
     </tr>
     
-    <tr >
+    <tr>
         <td class="time">11:35 - 12:05</td>
         <td><a href="/events/isc-spring-2019-speakers#thomas_froment">Thomas Froment</a> <span class="affiliation"> (Thales)</span></td>
         <td class="title">How we implement Inner Source community in Thales?
@@ -63,8 +64,8 @@ Thales Inner Source Software (TISS) Community is born from the Thales Digital Tr
             </div>
         </td>
     </tr>
-<tr>
 
+    <tr>
         <td class="time">12:10 - 12:40</td>
         <td><a href="/events/isc-spring-2019-speakers">Ben van 't Ende</a> <span class="affiliation"> (Age of Peers)</span></td>
         <td class="title">Detox your Inner Source
@@ -75,49 +76,49 @@ Collaborative practices are adopted naturally by participants in today’s open 
         </td>
     </tr>
 
- <tr>
+    <tr>
         <td class="time">12:45 - 13:45</td>
         <td colspan="2">Lunch</td>
-  </tr>
+    </tr>
 
- <tr>
+    <tr>
         <td class="time">13:50 - 14:50</td>
         <td><a href="/events/isc-spring-2019-speakers#katrina_novakovic">Katrina Novakovic</a> <span class="affiliation"> (Redhat)</span></td>
 
-   <td class="title">Workshop: Most organisations are Better than they Think 
+        <td class="title">Workshop: Most organisations are Better than they Think 
             <span onClick="toggleAbstract('novakovic-1')" class="abstract-toggle">(<a id="novakovic-1-link">Show Abstract</a>)</span>
             <div style="display:none" class="abstract" id="novakovic-1">
 Red Hat, the world's leading provider of Open Source Enterprise solutions, has open sourced an assessment tool, called Open Source Maturity Assessment (OSMA), to allow organisations to understand their current maturity regarding their knowledge, adoption and ability to effectively utilize Open Source / Inner Source technologies within their organisation. The assessment poses a number of questions with multiple choice answers around the following key areas: Business Goals, General Knowledge of Open Source, Development Standards and Tools, Upstream Community Participation, Governance & Legal Policies and Senior Management Support. The results of the assessment are used as a starting point to give an organisation a better understanding of their business goals regarding Open Source / Inner Source software and methodologies, the focus areas to address (under the areas of consume, contribute, create and strategy/governance) and recommended next steps. During this workshop, we will: 
         <ul>
-          <li>Have each individual attendee run through the assessment tool to determine their organisation's maturity </li>
-               <li> Analyse the results to highlight areas for an organisation to focus on</li>
-                    <li> Hold an open discussion on organisation maturity, including issues encountered and ways to increase the maturity level The assessment itself is Open Source and the code can be found at https://github.com/boogiespook/osma.</li>
-            </ul>  
-                        It is a simple LAMP stack, allowing questions and responses to be customised for an organisation. The maturity tool has been presented and then used by a number of organisations, large and small, to help them understand where they are on their Open Source journey.
-</div>
-        </td>
-    </tr>
-
-
-<tr >
-       <td class="time">14:55 - 15:25</td>
-
-   <td class="author"><a href="/events/isc-spring-2019-speakers#hong_dang">Hong Phuc Dang</a><span class="affiliation"> (Zalando)</span></td>
-        <td class="title">Open Source within the walls: The Case of a German fashion Platform
-            <span onClick="toggleAbstract('dong-1')" class="abstract-toggle">(<a id="dong-1-link">Show Abstract</a>)</span>
-            <div style="display:none" class="abstract" id="dong-1">
-This presentation covers InnerSource Discovery Phase at Zalando and best practices that are currently adopted throughout the company. 
+            <li>Have each individual attendee run through the assessment tool to determine their organisation's maturity </li>
+            <li> Analyse the results to highlight areas for an organisation to focus on</li>
+            <li> Hold an open discussion on organisation maturity, including issues encountered and ways to increase the maturity level The assessment itself is Open Source and the code can be found at https://github.com/boogiespook/osma.</li>
+        </ul>  
+            It is a simple LAMP stack, allowing questions and responses to be customised for an organisation. The maturity tool has been presented and then used by a number of organisations, large and small, to help them understand where they are on their Open Source journey.
             </div>
         </td>
     </tr>
 
-<tr >
+
+    <tr>
+       <td class="time">14:55 - 15:25</td>
+
+    <td class="author"><a href="/events/isc-spring-2019-speakers#hong_dang">Hong Phuc Dang</a><span class="affiliation"> (Zalando)</span></td>
+    <td class="title">Open Source within the walls: The Case of a German fashion Platform
+        <span onClick="toggleAbstract('dong-1')" class="abstract-toggle">(<a id="dong-1-link">Show Abstract</a>)</span>
+        <div style="display:none" class="abstract" id="dong-1">
+This presentation covers InnerSource Discovery Phase at Zalando and best practices that are currently adopted throughout the company. 
+        </div>
+        </td>
+    </tr>
+
+    <tr>
         <td class="time">15:30 - 15:55</td>
         <td colspan="2">Coffee Break</td>
     </tr>
 
 
-  <tr >
+    <tr>
         <td class="time">16:00 - 16:30</td>
         <td class="author"><a href="/events/isc-spring-2019-speakers#shelly_nezri">Shelly Nezri</a> <span class="affiliation"> (Elbit Systems Ltd.)</span></td>
         <td class="title">Gamification as a means of cultural change and an InnerSource engagement booster
@@ -128,26 +129,22 @@ When Elbit Systems launched its InnerSource program, it decided to drive cultura
         </td> 
     </tr>
 
-<tr >
+    <tr>
         <td class="time">16:35 - 17:05</td>
-
-   <td class="author"><a href="/events/isc-spring-2019-speakers#wolfgang_gehring">Wolfgang Gehring</a><span class="affiliation">(Daimler)</span></td>
+        <td class="author"><a href="/events/isc-spring-2019-speakers#wolfgang_gehring">Wolfgang Gehring</a><span class="affiliation">(Daimler)</span></td>
         <td class="title">Case Study: Daimler’s Path Towards Inner Source
             <span onClick="toggleAbstract('gehring-1')" class="abstract-toggle">(<a id="gehring-1-link">Show Abstract</a>)</span>
             <div style="display:none" class="abstract" id="gehring-1">
-</br>
 So you have decided that Inner Source is the way to go for your enterprise. Good for you! The rest is just a piece of cake. You only need to explain to your employees what this is all about. Oh yeah, and talk to the people from corporate tax, should be no problem, you know a guy there. Then get the legal department to answer some simple questions, and off you go! Ok, tooling is an issue, too. And governance... Alright, so you haven’t thought about all the minor details, but you just get everybody’s attention and spread the word. Easy! Right?!? Well, let me talk a little bit about our journey at Daimler. We haven’t solved everything yet, but we’re on a good path, and maybe our experience can help you a bit, too. 
-</div>
+            </div>
         </td>
     </tr>
 
-<tr>
+    <tr>
         <td class="time">17:10 - 17:20</td>
-
-   <td colspan="2">Closing (Dr. Lorraine Morgan)</td>
+        <td colspan="2">Closing (Dr. Lorraine Morgan)</td>
     </tr>
-    </table>
-
+</table>
 
 
 <table class="schedule">
@@ -160,42 +157,41 @@ So you have decided that Inner Source is the way to go for your enterprise. Good
         <td class="time">09:00 - 09:10</td>
         <td colspan="2" >
             Opening (Dr. Lorraine Morgan)
-</td>
+        </td>
     </tr>
 
 
-<tr>
+    <tr>
         <td class="time">09:15 - 10:15</td>
-<td class="author">
-    <span class="affiliation">TBC</span></td>
+        <td class="author"><span class="affiliation">TBC</span></td>
         <td class="title"><span class="keynoteTag">Keynote:</span> TBC
             <span onClick="toggleAbstract(tbc-1')" class="abstract-toggle">(<a id="tbc-1-link">Show Abstract</a>)</span>
             <div style="display:none" class="abstract" id="tbc-1">
 Details appearing shortly 
-</div>
+            </div>
         </td>
     </tr>
    
- <tr >
+    <tr>
         <td class="time">10:20 - 10:50</td>
         <td colspan="2">Coffee Break</td>
     </tr>
 
- <tr>
+    <tr>
         <td class="time">10:55 - 11:25</td>
         <td class="author"><a href="/events/isc-spring-2019-speakers#daniel_izquierdo_cortázar">Daniel Izquierdo Cortázar</a> <span class="affiliation">(Bitergia)</span></td>
-<td class="title"> Thoughts on adopting InnerSource and/or Agile
+        <td class="title"> Thoughts on adopting InnerSource and/or Agile
             <span onClick="toggleAbstract('cortázar-1')" class="abstract-toggle">(<a id="cortázar-1-link">Show Abstract</a>)</span>
-<div style="display:none" class="abstract" id="cortázar-1">
+            <div style="display:none" class="abstract" id="cortázar-1">
 One of the main questions that any company willing to try InnerSource is how this can be integrated with their current way of developing. Even more, some of them have recently started with Agile and this may be seen as ‘yet another software development approach’. Agile and InnerSource are defined in both cases and [e.g.: in the Wikipedia] as software development practices. However it seems that it is still not clear how each of them can complement the other. This talk aims at bringing on the table some thoughts on how Agile is being used by some large corporations, and how InnerSource is being applied by some others. We do not aim at stating facts, but at opening a fruitful discussion with the audience with the goal of bringing more uses cases and sharing experiences among the attendees.            
-    </div>
+            </div>
         </td>
     </tr>
 
 
-   <tr >
+   <tr>
         <td class="time">11:30 - 12:00</td>
-<td class="author"><a href="/events/isc-spring-2019-speakers#olivier_liechti">Olivier Liechti</a> <span class="affiliation">(Avalia Systems)</span></td>
+        <td class="author"><a href="/events/isc-spring-2019-speakers#olivier_liechti">Olivier Liechti</a> <span class="affiliation">(Avalia Systems)</span></td>
         <td class="title"> Agile transformation at Softplan: guiding teams with data-driven experiments
             <span onClick="toggleAbstract('liechti-1')" class="abstract-toggle">(<a id="liechti-1-link">Show Abstract</a>)</span>
             <div style="display:none" class="abstract" id="liechti-1">
@@ -204,27 +200,28 @@ How do you bring a legacy Enterprise Resource Planning (ERP) to "The Cloud", wit
         </td>
     </tr>
 
- <tr>
+    <tr>
         <td class="time">12:05 - 13:00</td>
         <td colspan="2">Lunch</td>
     </tr>
 
-<tr>
+    <tr>
         <td class="time">13:05 - 14:30</td>
-            <td class="author"><a href="/events/isc-spring-2019-speakers">Kristoff Van Tomme</a> <span class="affiliation">(Provonix)</span>
+        <td class="author"><a href="/events/isc-spring-2019-speakers">Kristoff Van Tomme</a> <span class="affiliation">(Provonix)</span>
         <td class="title"> Workshop: Dealing with common InnerSource Issues through Developer Portals
             <span onClick="toggleAbstract('van_tomme-1')" class="abstract-toggle">(<a id="van_tomme-1-link">Show Abstract</a>)</span>
             <div style="display:none" class="abstract" id="van_tomme-1">
-During the last InnerSource Commons and Patterns sessions, there have been a set of issues raised by the community. Those are related to the discoverability, findability, awareness, documentation, and others. In this talk, Kristof Van Tomme and Daniel Izquierdo will discuss the use of a Developer Portal as a way to centralize and deal with all of these related patterns. After the introduction we will split out into discussion groups to work on key patterns that the audience believes need to be included in most innersourcing portals.            </div>
+During the last InnerSource Commons and Patterns sessions, there have been a set of issues raised by the community. Those are related to the discoverability, findability, awareness, documentation, and others. In this talk, Kristof Van Tomme and Daniel Izquierdo will discuss the use of a Developer Portal as a way to centralize and deal with all of these related patterns. After the introduction we will split out into discussion groups to work on key patterns that the audience believes need to be included in most innersourcing portals.
+            </div>
         </td>
     </tr>
 
-<tr >
+    <tr>
         <td class="time">14:35 - 15:00</td>
         <td colspan="2">Coffee Break</td>
     </tr>
 
-<tr >
+    <tr>
         <td class="time">15:05 - 15:35</td>
         <td class="author"><a href="/events/isc-spring-2019-speakers#malcolm_herbert">Malcolm Herbert</a> <span class="affiliation">(Red Hat)</span></td>
         <td class="title"> Why Inner Source when you can Open Source
@@ -235,26 +232,22 @@ Over the last 10 years, Red Hat Consulting has offered services around open sour
         </td> 
     </tr>
 
-<tr >
+    <tr>
         <td class="time">15:40 - 16:10</td>
-        <td class="author"><a href="/events/isc-spring-2019-speakers#kevin_newman">Kevin Newman 
-</a></span></td>
+        <td class="author"><a href="/events/isc-spring-2019-speakers#kevin_newman">Kevin Newman</a></td>
         <td class="title"> How to fail implementing InnerSource
             <span onClick="toggleAbstract('newman-1')" class="abstract-toggle">(<a id="newman-1-link">Show Abstract</a>)</span>
             <div style="display:none" class="abstract" id="newman-1">
 An informal, but hopefully informative, presentation on the challenges of implementing InnerSource at a medium-sized, non-technical company. Harvard Business Publishing’s mission is to improve the practice of management in a changing world, and our areas of focus are in publishing and learning pedagogies. We thoughtfully recognize that while we are not a “technology” company, we treat software engineering as a core competency that can make or break our strategy. Adopting InnerSource was seen as a key component in our long term plans but fell far short of our expectations. We’d like to share our experience not as an any inherent indictment of InnerSource but as cautionary tale of intent and aspiration versus every day and unexciting, but very real, constraints. 
-    </div>
+        </div>
         </td>
     </tr>
 
-
-
-
-<tr >
+    <tr>
         <td class="time">16:15 - 16:45</td>
         <td class="author"><a href="/events/isc-spring-2019-speakers#max_campraro"> Max Capraro <br>
             <a href="/events/isc-spring-2019-speakers#johannes_tigges">Johannes Tigges
-</span></td>
+        </td>
         <td class="title"> The Inner Source Learning Path
             <span onClick="toggleAbstract('campraro-1')" class="abstract-toggle">(<a id="campraro-1-link">Show Abstract</a>)</span>
             <div style="display:none" class="abstract" id="campraro-1">
@@ -263,18 +256,16 @@ Inner source is the application of open source methodologies to internally-devel
         </td>
     </tr>
 
-  <tr >
+    <tr>
         <td class="time">16:50 - 17:00</td>
         <td colspan="2"> Wrap-Up – Feedback (Dr. Lorraine Morgan)</td>
     </tr>
 
-<tr >
+    <tr>
         <td class="time">TBC</td>
         <td colspan="2">Social Event</td>
     </tr>
-
 </table>    
-
 
 <table class="schedule">
     <tr>
@@ -284,14 +275,12 @@ Inner source is the application of open source methodologies to internally-devel
     </tr>
     <tr>
         <td class="time">09:00 - 09:10</td>
-<td colspan="2">
+        <td colspan="2">
             Opening (Dr. Lorraine Morgan)
         </td>
     </tr>
- 
- 
- 
-<tr >
+  
+    <tr>
         <td class="time">09:15 - 10:15</td>
         <td class="author"><a href="/events/isc-spring-2019-speakers#brian_fitzgerald">Brian Fitzgerald</a> <span class="affiliation">(Director of Lero, University of Limerick)</span></td>
         <td class="title"><span class="keynoteTag">Keynote:</span> Crowdsourcing Software Development: Silver Bullet or Lead Balloon
@@ -299,28 +288,27 @@ Inner source is the application of open source methodologies to internally-devel
             <div style="display:none" class="abstract" id="fitzgerald-1">
 Crowdsourcing is emerging as an alternative outsourcing strategy which is gaining increasing attention in the software engineering community. However, crowdsourcing software development involves complex tasks which differ significantly from the micro-tasks that can be found on crowdsourcing platforms such as Amazon Mechanical Turk—the latter are much shorter in duration, and typically very simple and do not involve any task interdependencies. To achieve the potential benefits of crowdsourcing in the software development context, companies need to understand how this strategy works, what challenges arise, and what factors might affect crowd participation. Research to date on crowdsourcing software development has tended to focus on the ‘crowd’ or the technical platform, with little research from the perspective of the customer who is seeking to leverage the crowdsourcing development model. The findings from an in-depth case study of crowd-sourcing software development in a Fortune 500 company are augmented with an analysis of over 13,000 crowdsourcing competitions over a ten-year period on the Topcoder crowdsourcing platform, one of the most popular platforms for software development, are drawn on to evaluate the effectiveness of crowdsourcing in a software development context.
             </div>
-            </td>
-                 </tr>
-           </tr>
-    <tr >
+        </td>
+    </tr>
+    
+    <tr>
         <td class="time">10:20 - 10:45</td>
         <td colspan="2">Coffee Break</td>
     </tr>
 
-   <tr>
+    <tr>
         <td class="time">10:50 - 11:20</td>
-
         <td class="author">
-<a href="/events/isc-spring-2019-speakers#daniel_izquierdo_cortázar">Daniel Izquierdo Cortázar</a> <span class="affiliation">(Bitergia)</span></td>
-<td class="title">Metrics and KPIs for an InnerSource Office 
-     <span onClick="toggleAbstract('cortázar-2')" class="abstract-toggle">(<a id="cortázar-2-link">Show Abstract</a>)</span>
-<div style="display:none" class="abstract" id="cortázar-2">
-
+            <a href="/events/isc-spring-2019-speakers#daniel_izquierdo_cortázar">Daniel Izquierdo Cortázar</a> <span class="affiliation">(Bitergia)</span></td>
+        <td class="title">Metrics and KPIs for an InnerSource Office 
+            <span onClick="toggleAbstract('cortázar-2')" class="abstract-toggle">(<a id="cortázar-2-link">Show Abstract</a>)</span>
+            <div style="display:none" class="abstract" id="cortázar-2">
 Metrics are an important part of the InnerSource journey. The InnerSource Commons has been a great place for discussion around the topic. Specifically the InnerSource Patterns community delivered a pattern focused on first steps with metrics [1] where no specific metrics are detailed, but this gives a starting point to discuss when, how and what to measure. This talk aims at detailing these set of metrics and KPIs for further discussion across the community. This is based on work in progress in the GrimoireLab/CHAOSS community, a Linux Foundation Project. The proposed set of metrics are split into three main areas: Activity, Community and Process. [1] https://github.com/InnerSourceCommons/InnerSourcePatterns/blob/master/introducing-metrics-in-innersource.md
-</div>
+            </div>
         </td>
     </tr>
-<tr >
+
+    <tr>
         <td class="time">11:25 - 11:55</td>
         <td class="author"><a href="/events/isc-spring-2019-speakers#tobie_langel">Tobie Langel</a> <span class="affiliation">(UnlockOpen)</span></td>
         <td class="title">Making the Business Case for Contributing to Open Source
@@ -331,33 +319,33 @@ Details appearing shortly
         </td>
     </tr>
 
-<tr>
+    <tr>
         <td class="time">12:00 - 12:55</td>
         <td colspan="2">Lunch</td>
     </tr>
 
-   <tr >
+   <tr>
         <td class="time">13:00 - 13:45</td>    
-<td class="author"><a href="/events/isc-spring-2019-speakers">Kristoff Van Tomme </a><span class="affiliation">(Provonix)</span>
-<td class="title">7 cultural insights to help you reinvent your organization            
-<span onClick="toggleAbstract('VanTomme-1')" class="abstract-toggle">(<a id="VanTomme-1-link">Show Abstract</a>)</span>
+        <td class="author"><a href="/events/isc-spring-2019-speakers">Kristoff Van Tomme </a><span class="affiliation">(Provonix)</span></td>
+        <td class="title">7 cultural insights to help you reinvent your organization            
+            <span onClick="toggleAbstract('VanTomme-1')" class="abstract-toggle">(<a id="VanTomme-1-link">Show Abstract</a>)</span>
             <div style="display:none" class="abstract" id="VanTomme-2">
 Culture is hard to describe, and even harder to emulate. So how do you even start to establish an open source-like culture? What are the underlying principles on which these cultures are built? For the past 13 years, I’ve been reading and thinking about these questions, trying to understand what makes some open source projects succeed and causes others to fail. In this talk I want to introduce 7 mental models and surprising insights that I have adopted along te way that have transformed the way I think about business. I will present the insights together with references to the books from which they were derived, and explain why I believe they can help an organisation to build an open source-like culture.
-    </div>
+            </div>
         </td>
     </tr>
 
-   <tr >
+   <tr>
         <td class="time">13:50 - 14:30</td>
-        <td class="author"><a href="/events/isc-spring-2019-speakers#danese_cooper">Danese Cooper</a> 
-</td>
+        <td class="author"><a href="/events/isc-spring-2019-speakers#danese_cooper">Danese Cooper</a></td>
         <td class="title">Governance Meeting
             <span onClick="toggleAbstract('cooper-1')" class="abstract-toggle"><a id="cooper-1-link"></a></span>
             <div style="display:none" class="abstract" id="cooper-1">
             </div>
         </td>
     </tr>
-<tr >
+    
+    <tr>
         <td class="time">14:35 - 14:45</td>
         <td colspan="2">Closing (Dr. Lorraine Morgan)</td>
     </tr>


### PR DESCRIPTION
There was a couple of rendering issues on the page, due to some tag pairs missing/extra tags

![image](https://user-images.githubusercontent.com/1150270/55160022-46e79780-515a-11e9-9494-9547dac81b30.png)
![image](https://user-images.githubusercontent.com/1150270/55160043-4f3fd280-515a-11e9-9124-efc8779f7cac.png)

I've gone through and done a tag pairing/matching exercise. Along the way I standardised the indenting/whitespace for ease of spotting the tagging.