### PR TITLE
fixed jekyll build errors - updated config & update liquid templates

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -52,7 +52,7 @@ logo: "isc-border.png"
 #   /_/    \__,_/\__, /_/_/ /_/\__,_/\__/_/\____/_/ /_/
 #               /____/
 #
-gems:
+plugins:
     - jekyll-gist
     - jekyll-paginate
     - jekyll-redirect-from

--- a/_layouts/page-fullwidth.html
+++ b/_layouts/page-fullwidth.html
@@ -5,8 +5,8 @@ format: page-fullwidth
 {% if page.image.title %}
 <div class="row t30">
 	<div class="small-12 columns">
-		<img src="{{ site.urlimg }}{{ page.image.title }}" width="970" alt="{{ page.title escape }}">
-		{% if page.image.caption_url && page.image.caption %}
+		<img src="{{ site.urlimg }}{{ page.image.title }}" width="970" alt="{{ page.title | escape }}">
+		{% if page.image.caption_url and page.image.caption %}
 		<p class="text-right caption">
 			<a href="{{ page.image.caption_url }}">{{ page.image.caption }}</a>
 		</p>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -9,9 +9,9 @@ format: post
 			<header>
 				{% if page.image.title %}
 				<figure>
-					<img src="{{ site.urlimg }}{{ page.image.title }}" width="970" alt="{{ page.title escape }}" itemprop="image">
+					<img src="{{ site.urlimg }}{{ page.image.title }}" width="970" alt="{{ page.title | escape }}" itemprop="image">
 
-					{% if page.image.caption_url & page.image.caption %}
+					{% if page.image.caption_url and page.image.caption %}
 					<figcaption class="text-right">
 						<a href="{{ page.image.caption_url }}">{{ page.image.caption }}</a>
 					</figcaption>


### PR DESCRIPTION
Jekyll was throwing a number of warnings on build (possibly due to the recent upgrades).

```
       Deprecation: The 'gems' configuration option has been renamed to 'plugins'. Please update your config file accordingly.
```
```
    Liquid Warning: Liquid syntax error (line 7): Expected end_of_string but found id in "{{ page.title escape }}" in /_layouts/page.html
    Liquid Warning: Liquid syntax error (line 9): Unexpected character & in "page.image.caption_url & page.image.caption" in /_layouts/page.htm
```
etc.