### PR TITLE
Add link to Product Owner Videos on O'Reilly

### DIFF
--- a/resources/learningpath.md
+++ b/resources/learningpath.md
@@ -10,7 +10,7 @@ Their production was kindly sponsored by PayPal. The Learning Path section intro
 Once finished, the first edition of the Inner Source Learning Path will cover the following sections:
 
 1. [Introduction]
-1. Product Owner *(coming soon...)*
+1. [Product Owner]
 1. [Trusted Committer]
 1. Contributor *(comming soon...)*
 
@@ -23,4 +23,5 @@ We invite you to help us finishing the Inner Source Learning Paths. Checkout the
 [#learning-path]: https://paypalflow.slack.com/messages/CARTU4XV2
 [Trusted Committer]: https://learning.oreilly.com/videos/the-trusted-committer/9781492047599
 [Introduction]: https://learning.oreilly.com/videos/introduction-to-innersource/9781492041504
+[Product Owner]: https://learning.oreilly.com/videos/innersource-product-owners/9781492046707
 [http://bit.ly/inner-source-learning-path]: http://bit.ly/inner-source-learning-path


### PR DESCRIPTION
Here's a PR to add a link to the released Product Owner videos on the O'Reilly Platform based on the Link @clobner published in https://github.com/InnerSourceCommons/InnerSourceLearningPath/issues/16#issuecomment-499481618

We could merge that now or wait until we have articles for it. Opinions?