### PR TITLE
Wire ISC.S9 Coordinates into the ISC website

### DIFF
--- a/_includes/_sidebar.html
+++ b/_includes/_sidebar.html
@@ -1,29 +1,29 @@
 <aside>
-	<div class="panel radius">
-		<h3><a href="/events/">ISC Events</a></h3>
+    <div class="panel radius">
+        <h3><a href="/events/">ISC Events</a></h3>
         
-		<p>The <a target="_blank" href="https://www.innersource.events/">Fall 2019 summit</a> will be held in Baltimore, MD, USA from 17-19 September 2019. We look forward to another exciting lineup and thought leadership speakers. For more information, check out the <a href="https://www.innersource.events/" target="_blank">innersource.events</a>. The <a href="https://docs.google.com/forms/d/e/1FAIpQLSfmSoIvuvHa1HwaX_PllPojAuMO8hFCJgYU7D0Mcdp5sJma_Q/viewform?vc=0&c=0&w=1" target="_blank">call for presentations</a> is still open. Hope to see you there!	
-		</p>
+        <p>The <a target="_blank" href="https://www.innersource.events/">Fall 2019 summit</a> will be held in Baltimore, MD, USA from 17-19 September 2019. We look forward to another exciting lineup and thought leadership speakers. For more information, check out the <a href="https://www.innersource.events/" target="_blank">innersource.events</a>. The <a href="https://docs.google.com/forms/d/e/1FAIpQLSfmSoIvuvHa1HwaX_PllPojAuMO8hFCJgYU7D0Mcdp5sJma_Q/viewform?vc=0&c=0&w=1" target="_blank">call for presentations</a> is still open. Hope to see you there!    
+        </p>
 
         <p><a href="/events">Information on past events</a> is available.</p>
-	</div>
+    </div>
     <div class="panel radius">
         <h3><a href="http://www.oreilly.com/pub/e/3884">O'Reilly Webinar</a></h3>
         <p>Learn about <a href="https://github.com/InnerSourceCommons/InnerSourcePatterns">InnerSource Patterns</a> by watching the replay of the <em>Implementing InnerSource Patterns: Solve Organizational Problems by Leveraging Community Contributions</em> webinar from Thursday, June 1, 2017.
         </p>
     </div>
 
-	<div class="panel radius">
-	  <h3><a href="/assets/files/InnerSourceCommonsSurvey2016.pdf">InnerSource Survey</a></h3>
-	  <p>
-	    Many organizations care about InnerSource - some are already deeply involved, some just considering starting. Here are the results from the <a href="/assets/files/InnerSourceCommonsSurvey2016.pdf">2016 InnerSource Survey</a>
-	  </p>
-	</div>
-	
+    <div class="panel radius">
+      <h3><a href="/assets/files/InnerSourceCommonsSurvey2016.pdf">InnerSource Survey</a></h3>
+      <p>
+        Many organizations care about InnerSource - some are already deeply involved, some just considering starting. Here are the results from the <a href="/assets/files/InnerSourceCommonsSurvey2016.pdf">2016 InnerSource Survey</a>
+      </p>
+    </div>
+    
   <div class="border-dotted radius b30">
     <p class="text-left">
       Connect with the community
-	<script async defer src="https://isc-inviter.herokuapp.com/slackin.js"></script>
+    <script async defer src="https://isc-inviter.herokuapp.com/slackin.js"></script>
     </p>
     <p class="text-left">
       This site maintained on <a href="https://github.com/InnerSourceCommons/innersourcecommons.org">GitHub</a>

--- a/_includes/_sidebar.html
+++ b/_includes/_sidebar.html
@@ -2,7 +2,7 @@
     <div class="panel radius">
         <h3><a href="/events/">ISC Events</a></h3>
         
-        <p>The <a target="_blank" href="https://www.innersource.events/">Fall 2019 summit</a> will be held in Baltimore, MD, USA from 17-19 September 2019. We look forward to another exciting lineup and thought leadership speakers. For more information, check out the <a href="https://www.innersource.events/" target="_blank">innersource.events</a>. The <a href="https://docs.google.com/forms/d/e/1FAIpQLSfmSoIvuvHa1HwaX_PllPojAuMO8hFCJgYU7D0Mcdp5sJma_Q/viewform?vc=0&c=0&w=1" target="_blank">call for presentations</a> is still open. Hope to see you there!    
+        <p>The <a target="_blank" href="https://www.innersource.events/">Fall 2019 summit</a> will be held in Baltimore, MD, USA from 17-19 September 2019. We look forward to another exciting lineup and thought leadership speakers. For more information, check out <a href="https://www.innersource.events/" target="_blank">www.innersource.events</a>. The <a href="https://docs.google.com/forms/d/e/1FAIpQLSfmSoIvuvHa1HwaX_PllPojAuMO8hFCJgYU7D0Mcdp5sJma_Q/viewform?vc=0&c=0&w=1" target="_blank">call for presentations</a> is still open. Hope to see you there!    
         </p>
 
         <p><a href="/events">Information on past events</a> is available.</p>

--- a/_includes/_sidebar.html
+++ b/_includes/_sidebar.html
@@ -1,10 +1,10 @@
 <aside>
 	<div class="panel radius">
 		<h3><a href="/events/">ISC Events</a></h3>
-        The <a href="/events/isc-spring-2019/">Spring 2019 summit</a> will be held in Galway, Ireland from 9-11 April 2019. We look forward to another exciting lineup and thought leadership speakers. Hope to see you there! For more information, check out our <a href="https://innersourcecommons.org/events/isc-spring-2019-agenda/" alt="Agenda">Agenda</a> and details on <a href="https://innersourcecommons.org/events/isc-spring-2019-speakers/" alt="Speakers"> Speakers</a>.	
+        
+		<p>The <a target="_blank" href="https://www.innersource.events/">Fall 2019 summit</a> will be held in Baltimore, MD, USA from 17-19 September 2019. We look forward to another exciting lineup and thought leadership speakers. For more information, check out the <a href="https://www.innersource.events/" target="_blank">innersource.events</a>. The <a href="https://docs.google.com/forms/d/e/1FAIpQLSfmSoIvuvHa1HwaX_PllPojAuMO8hFCJgYU7D0Mcdp5sJma_Q/viewform?vc=0&c=0&w=1" target="_blank">call for presentations</a> is still open. Hope to see you there!	
 		</p>
 
-        <p>The <a href="/events/isc-fall-2018/">Fall 2018 summit</a> October 3-5, is now over, with its impressive <a href="https://innersourcecommons.org/events/isc-fall-2018-agenda" alt="Agenda">Agenda</a> and exciting lineup of <a href="https://innersourcecommons.org/events/isc-fall-2018-speakers" alt="Speakers"> Speakers</a> and thought leadership. The group photo from Islandia, NY is now on the <a href="/events/isc-fall-2018/">ISC.S7 event page</a>.</p>
         <p><a href="/events">Information on past events</a> is available.</p>
 	</div>
     <div class="panel radius">

--- a/events/index.md
+++ b/events/index.md
@@ -3,13 +3,13 @@ layout: page
 title: 'Upcoming InnerSource Events'
 ---
 
-## Current Events
-* [Commons Summit 8 - Spring 2019](isc-spring-2019)
-   - InnerSource Commons Summit 8 - Galway, Ireland - April 9-11
-
 ## Upcoming Events
+* [Commons Summit 9 - Fall 2019](https://www.innersource.events/)
+   - InnerSource Commons Summit 9 - Baltimore, MD, USA - September 17-19
 
 ## Prior Events
+* [Commons Summit 8 - Spring 2019](isc-spring-2019)
+   - InnerSource Commons Summit 8 - Galway, Ireland - April 9-11
 * [Commons Summit 7 - Fall 2018](isc-fall-2018)
     - InnerSource Commons Summit 7 - New York, USA - Oct 3-5
 * [Commons Summit 6 - Spring 2018](isc-spring-2018)


### PR DESCRIPTION
This merge requests wires the ISC.S9 (Baltimore summit) coordinates into the website by:

- Adapting the side bar 
- Erasing past summits from side bar
- Adapting the events page (adding ISC.S9, moving ISC.S8 to 'past events')