### PR TITLE
Add contacts according to self-stated at #40

### DIFF
--- a/pages/contact.md
+++ b/pages/contact.md
@@ -19,7 +19,7 @@ Reach out to any of these people that are willing to be publicly quoted or speak
 | Max Capraro | [Friedrich-Alexander-Universität Erlangen-Nürnberg](https://www.fau.eu/) | Scientific Staff | Germany | - | Y |
 | Danese Cooper | [NearForm](https://www.nearform.com/) | VP Special Initiatives | Worldwide | Y | Y |
 | Isabel Drost-Fromm | [Europace AG](https://www.europace.de/) | Open Source Strategist | Germany | - | Y |
-| Georg Gruetter | [Robert BOsch](https://www.bosch.com/) | Chief Expert | Germany | - | Y |
+| Georg Gruetter | [Robert Bosch](https://www.bosch.com/) | Chief Expert | Germany | - | Y |
 | Daniel Izquierdo Cortázar | [Bitergia](https://bitergia.com) | Chief Data Officer | Spain/Worldwide | Y | Y |
 | Russ Rutledge | [InnerSource Commons](https://innersourcecommons.org) | Member | United States | Y | Y |
 | Johannes Tigges | [Here](https://www.here.com/) | Open Source InnerSource Office | Germany | - | Y |

--- a/pages/contact.md
+++ b/pages/contact.md
@@ -11,9 +11,15 @@ permalink: "/contact/"
 * Join the [#innersourcecommons](https://isc-inviter.herokuapp.com/) slack channel
     - *Should the inviter be down, please email the address above.*
 
-Reach out to any of these people that are willing to be publicly quoted or speak on InnerSource
+Reach out to any of these people that are willing to be publicly quoted or speak on InnerSource. They are ordered by surname.
 
-| Name | Company | Title | Location | Quoted | Speak |
+| Name | Current Employer | Title | Location | Quoted | Speak |
 |------|---------|-------|----------|--------|-------|
+| Max Capraro | [Friedrich-Alexander-Universität Erlangen-Nürnberg](https://www.fau.eu/) | Scientific Staff | Germany | - | Y |
 | Danese Cooper | [NearForm](https://www.nearform.com/) | VP Special Initiatives | Worldwide | Y | Y |
+| Isabel Drost-Fromm | [Europace AG](https://www.europace.de/) | Open Source Strategist | Germany | - | Y |
+| Georg Gruetter | [Robert BOsch](https://www.bosch.com/) | Chief Expert | Germany | - | Y |
+| Daniel Izquierdo Cortázar | [Bitergia](https://bitergia.com) | Chief Data Officer | Spain/Worldwide | Y | Y |
 | Russ Rutledge | [InnerSource Commons](https://innersourcecommons.org) | Member | United States | Y | Y |
+| Johannes Tigges | [Here](https://www.here.com/) | Open Source InnerSource Office | Germany | - | Y |
+| Ben Van't Ende | [Age of Peers](https://ageofpeers.com/) | Collaboration Strategist | Netherlands | - | Y |


### PR DESCRIPTION
Signed-off-by: Daniel Izquierdo Cortazar <dicortazar@gmail.com>

This change adds more people to the list according to issue #40 .

The list of people is ordered by surname.

Company column is updated to Current Employer as this states the affiliation, but not that this person is talking
on behalf of this organization.