### PR TITLE
Added nav links to reach contact page

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -46,6 +46,9 @@
 - title: "About"
   url: "/about/"
   side: left
+  dropdown:
+  - title: "Contact"
+    url: "/contact/"
 
 - title: "Wiki"
   url: "/wiki/"

--- a/pages/about.md
+++ b/pages/about.md
@@ -14,7 +14,7 @@ Interested individuals and companies are welcome to participate and contribute c
 
 The ISC was founded by PayPal in 2015.
 
-## Contact Information
+## [Contact Information](/contact/)
 * Email <questions@innersourcecommons.org>
 * Join the [#innersourcecommons](https://isc-inviter.herokuapp.com/) slack channel
 


### PR DESCRIPTION
The Contact page was floating free - with nothing actually linking to
it. This should now be fixed through the following:

* Linked the _Contact Information_ header on the About page.
* Added a dropdown link under the about header item at the top.