### PR TITLE
Add a redirect link to our current Slack inviter

### DIFF
--- a/pages/slackinvite.md
+++ b/pages/slackinvite.md
@@ -1,0 +1,8 @@
+---
+layout: page
+show_meta: false
+title: 'InnerSource'
+permalink: "/slackinvite/"
+redirect_to: 
+    - https://innersourcecommons-inviter.herokuapp.com/
+---


### PR DESCRIPTION
This adds a redirect link `innersourcecommons.org/slackinvite` similar to `innersourcecommons.org/learningpath` or `innersourcecommons.org/patterns` for nice looking use in presentations. 
Also adds an indirection to have this stable to whatever our slack inviter URL might be in the future. Because [RFC1925](https://tools.ietf.org/html/rfc1925) is too correct for an April 1st RFC. 