### PR TITLE
Add bundler requirement to Travis file to fix builds and CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ language: ruby
 rvm:
 - 2.3.1
 
+before_install:
+- gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+- gem install bundler -v '< 2'
+
 # Assume bundler is being used, therefore
 # the `install` step will run `bundle install` by default.
 script: ./cibuild


### PR DESCRIPTION
Currently our CI and the website deployment fails due to missing bundler dependency.

This appears due to changes around bundler and Travis specifics. Here's some docs on it https://docs.travis-ci.com/user/languages/ruby/#bundler-20 

This PR is supposed to fix this.