### PR TITLE
Fixed sourcemap property - _config_dev.yml

### DIFF
--- a/_config_dev.yml
+++ b/_config_dev.yml
@@ -20,7 +20,7 @@ sass:
   # trace_selectors: true
   # debug_info: true
   # FUTURE https://github.com/jekyll/jekyll-sass-converter/issues/12
-  sourcemap: true
+  sourcemap: always
 
 # Disable when not in production
 google_analytics_tracking_id:


### PR DESCRIPTION
When trying to run the command `jekyll serve` using `_config_dev.yml`,
it failed with the following error:
```
  Conversion error: Jekyll::Converters::Scss encountered an error while converting 'assets/css/atom.scss': undefined method `to_sym' for true:TrueClass Did you mean? to_s
------------------------------------------------
Jekyll 4.0.0   Please append `--trace` to the `serve` command
               for any additional information or backtrace.
------------------------------------------------
```

This happens because in `_config_dev.yml` sourcemap is set to `true`,
while the documentation at
https://github.com/jekyll/jekyll-sass-converter stated the allowed
values are `never`, `always` and `development`.

This PR fixes #93, and the issue was noticed when implementing #91.