### PR TITLE
Feature gh#91  development environment setup with docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+!Gemfile
+!Gemfile.locks

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,29 @@ Contributions to this repo are welcome. Please follow the following guidelines:
 * The navigational links at the top of the pages are at \_data/\_navigation.yml
 * Event pages are under *events*; other main pages are under *pages*
 
+### Testing edits locally
+
+In both of options described below the website will be served with _livereload_, which means your changes should be automatically reflected on the browser after you save them.  
+Unless stated otherwise, the website will be served at https://localhost:4000.
+
+#### Native development environment
+
+Install ruby and the project dependencies, then run the command:
+```
+jekyll serve --config _config.yml,_config_dev.yml --livereload
+```
+
+#### Docker development environment
+
+If you have docker installed in your machine, you can run the development environment with the following commands on the root of the repository:
+- `docker-compose up` - for Docker on linux or [Docker Desktop](https://www.docker.com/products/docker-desktop) (Windows or Mac)
+
+OR
+- `docker-compose -f docker-compose-toolbox.yml` - for [Docker Toolbox](https://docs.docker.com/toolbox/toolbox_install_windows/) (legacy solution for older Mac and Windows systems)
+  - The website will be available at `https://<docker machine ip>:4000`, which is typically https://192.168.99.100:4000 - you can discover the ip with the command `docker-machine ip`
+
+In both cases a Docker image will be build on the first time you run the commands, this step can take a few minutes.
+
 ## git command line tips
 
 * Do this once when you've checked out your fork of the main ISC repo: `git remote add upstream https://github.com/InnerSourceCommons/innersourcecommons.org.git`

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,22 @@ WORKDIR /InnerSource
 ADD Gemfile .
 ADD Gemfile.lock .
 
+# Required in order to build gem native extenstions
+# see https://github.com/docker-library/ruby/issues/163
 RUN apk add --no-cache g++ gcc make musl-dev
+
+# Required to build in Docker for Mac, otherwise it will raise the
+# error: Could not find 'bundler'
 RUN bundle update --bundler
+
 RUN bundle install
 
-CMD jekyll serve --host 0.0.0.0 --config /source/_config.yml,/source/_config_dev.yml -s /source -d /dist
+# Required so that Jekyll will not override site.url with the host passed by --host
+ENV JEKYLL_ENV=docker
+
+EXPOSE 35729
+EXPOSE 4000
+
+# On --host 0.0.0.0
+# It is required so that Jekyll will accept connections outside of localhost and 127.0.0.1
+CMD jekyll serve --host 0.0.0.0 --livereload --config /source/_config.yml,/source/_config_dev.yml -s /source

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM ruby:2.7.0-alpine3.11
+
+WORKDIR /InnerSource
+ADD Gemfile .
+ADD Gemfile.lock .
+
+RUN apk add --no-cache g++ gcc make musl-dev
+RUN bundle update --bundler
+RUN bundle install
+
+CMD jekyll serve --host 0.0.0.0 --config /source/_config.yml,/source/_config_dev.yml -s /source -d /dist

--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@ This repo primarily serves to host the pages for InnerSource Commons. The master
 
 ## Contributing
 
-Please see [our contribution guidelines](CONTRIBUTING.md)
+Please see [our contribution guidelines and instructions](CONTRIBUTING.md).
 
 

--- a/_config_dev.yml
+++ b/_config_dev.yml
@@ -20,7 +20,7 @@ sass:
   # trace_selectors: true
   # debug_info: true
   # FUTURE https://github.com/jekyll/jekyll-sass-converter/issues/12
-  sourcemap: true
+  sourcemap: always
 
 # Disable when not in production
 google_analytics_tracking_id:

--- a/_config_dev_toolbox.yml
+++ b/_config_dev_toolbox.yml
@@ -1,0 +1,8 @@
+# This file is needed for setting up the development environment
+# with docker toolbox.
+# It reverts the absolute paths configured in _config_dev.yml
+# Without this, assets and links build with site.url would fail to
+# load or open.
+
+url: ''
+urlimg: 'images/'

--- a/docker-compose-toolbox.yml
+++ b/docker-compose-toolbox.yml
@@ -1,0 +1,13 @@
+version: "3.7"
+services:
+  jekyll:
+    build: .
+    image: innersource-website-devenv
+    ports:
+    - "4000:4000" # webpage
+    - "35729:35729" # live reload
+    volumes:
+    - ./:/source
+    # --force_polling is necessary as the sharing of the filesystem from host to the toolbox vm does not seem to trigger the regular rebuild on changes
+    # _config_dev_toolbox.yml - see the comments on the file
+    command: jekyll serve --host 0.0.0.0 --force_polling --livereload --config /source/_config.yml,/source/_config_dev.yml,/source/_config_dev_toolbox.yml -s /source

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     build: .
     image: innersource-website-devenv
     ports:
-    - "4000:4000"
+    - "4000:4000" # webpage
+    - "35729:35729" # live reload
     volumes:
     - ./:/source

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: "3.7"
+services:
+  jekyll:
+    build: .
+    image: innersource-website-devenv
+    ports:
+    - "4000:4000"
+    volumes:
+    - ./:/source


### PR DESCRIPTION
This commit enables the usage of Docker for setting up a development
environment.

It is an implementation for
#91

With this development, with the command `docker-compose up` or `docker-compose -f docker-compose-toolbox.yml up` (for Docker Toolbox), a docker
image is built and a docker contain is run serving the webpage, that
can be accessed on `http://localhost:4000` (or `http://<docker machine ip>:4000` for Docker Toolbox)

Files:
- `.dockerignore` - ensures that only the necessary files are used in
the context passed to the docker image build, saving build time
- `Dockerfile` - The commands used to build a docker image
- `docker-compose.yml` - Configuration for docker-compose, that enables
a simple development environment setup, automating the image build and
container orchestration
- `docker-compose-toolbox.yml` - docker-compose file with tweaks for Docker Toolbox (see comments on files)
- `_docker_dev_toolbox.yml` - overrides url configuration for Docker Toolbox (see comments on file)

Known limitations:
- ~Website is not rebuilt automatically when a file is changed, requiring
a container restart (this was expected to work out of the box with
`jekyll serve`, but testing showed it did not work)~
  - It was already working for Docker for Mac, implemented for Docker Toolbox with using the command line option `--force_polling`
- ~Docker Toolbox is not supported - with this version of docker, the
page can be loaded, but assets are not loaded, as the browser tries to
fetch them from http://0.0.0.0, and the website must be accessed on the
IP returned by `docker-machine ip`. More investigation is necessary.~
  - Implemented support with d538dc20f1905185e0e4adb68ee8258f57c417c0

Explanations:
- `RUN apk add --no-cache g++ gcc make musl-dev` - necessary for
building gem native extensions (eventmachine) - Error message "You have
to install development tools first."
- `RUN bundle update --bundler` - Image build on Docker Toolbox worked
without this, but when trying to build the image on Docker for Mac, it
raised the following error: ``find_spec_for_exe': Could not find
'bundler' (1.16.1) required by your /InnerSource/Gemfile.lock.
(Gem::GemNotFoundException)
To update to the latest version installed on your system, run `bundle
update --bundler`.``
- `--host 0.0.0.0` - without this line, jekyll will only accept traffice
incoming from `localhost` or `127.0.0.1`, which is not the case when
using Docker for Mac or Docker Toolbox, as it forwards traffic from the host to the
container. Without this line, the browser will show errors
ERR_CONNECTION_REFUSED (Toolbox) or ERR_EMPTY_RESPONSE (Mac).

Remarks:
- Only tested (by the author) on Docker for Mac and Docker Toolbox

Letf overs and follow ups:
- [x] Documentation on how to use the Docker environment is missing
  - Added with 88e41f2fc25cb9d50c00dc6f1cd6cc6b600f05c2
- [ ] Documentation on the overall solution for Docker environment is missing
  - The number of references, development iterations (until ready) and questions during review shows that even though the final solution is concise, there is a lot of non trivial aspects to it, therefore I would like to include some kind of documentation that explains how it works and more details on the whys of some things (decisions), and unused alternatives, this should help future refactoring - even though there is extensive information on the github issue #91 and this pr (#99) I have the strong feeling git repos should be self contained regarding their documentation (i.e. portable to other git managers such as bitbucket or gitlab)
- Decision Needed: Implement the left overs in this PR or approve and Merge the PR as is and document the leftovers with follow up issues - DONE - Document how to use in this PR, document overall Docker environment solution in a separate PR.
- [ ] Create follow up issue to review Contributing instructions with respect to test the build locally (see https://github.com/InnerSourceCommons/innersourcecommons.org/pull/99#issuecomment-595498798)
- [ ] Create follow up issue to reduce the technical debt introduce with this PR
  - Separate docker-compose files for regular docker and toolbox
  - Unexplained need for `RUN bundle update --bundler` only on Docker Desktop, but not on toolbox
  - Not using `jekyll/jekyll` image 

References:
- https://hub.docker.com/_/ruby
- https://docs.docker.com/engine/reference/builder/#dockerignore-file
- https://docs.docker.com/engine/reference/builder/
- docker-library/ruby#163 (How to install
eventmachine)
- https://stackoverflow.com/questions/41485217/mount-current-directory-as-a-volume-in-docker-on-windows-10
- https://stackoverflow.com/questions/42893475/how-to-run-jekyll-serve-pointing-to-another-directory
- https://stackoverflow.com/questions/50540721/docker-toolbox-error-response-from-daemon-invalid-mode-root-docker
- https://medium.com/@Charles_Stover/fixing-volumes-in-docker-toolbox-4ad5ace0e572
- https://sashabrava.github.io/2018/making-Jekyll-available-on-local-network.html
- microsoft/vscode-remote-release#764
- https://stackoverflow.com/questions/16608466/connect-to-a-locally-built-jekyll-server-using-mobile-devices-in-the-lan/16608698
- https://jekyllrb.com/docs/configuration/options/#serve-command-options
- https://tonyho.net/jekyll-docker-windows-and-0-0-0-0/
- Cannot set site.url to a different address than the --host flag address in development
  - jekyll/jekyll#5743
- https://docs.docker.com/engine/reference/builder/#expose

PS: I carried https://github.com/InnerSourceCommons/innersourcecommons.org/commit/f4edc9fd7c92006eaeba8c3cafe9758f8f58e4fe to this PR by mistake, but I imagine #98 will be approved before this one, so I will not undo that.