### PR TITLE
Added social media information

### DIFF
--- a/_data/socialmedia.yml
+++ b/_data/socialmedia.yml
@@ -9,7 +9,7 @@
   title: "Videos"
 
 - name: LinkedIn
-  url: https://www.youtube.com/channel/UCoSPSd6Or4F_vpjo4SmyoEA
+  url: https://linkedin.com/company/innersourcecommons
   class: icon-linkedin
   title: "LinkedIn Page"
 

--- a/_data/socialmedia.yml
+++ b/_data/socialmedia.yml
@@ -1,49 +1,19 @@
 - name: GitHub
   url: http://github.com/InnerSourceCommons/innersourcecommons.org
   class: icon-github
-  title: Code und mehr...
+  title: Code and more...
 
-# - name: YouTube
-#   url: http://www.youtube.com/PhlowMedia
-#   class: icon-youtube
-#   title: "Videos, Video-Anleitungen und Filme von Phlow auf YouTube"
+- name: YouTube
+  url: https://www.youtube.com/channel/UCoSPSd6Or4F_vpjo4SmyoEA
+  class: icon-youtube
+  title: "Videos"
 
-# - name: Twitter
-# url: http://twitter.com/PayPalFLOW
-# class: icon-twitter
-# title: "PayPal FLOW on Twitter"
+- name: LinkedIn
+  url: https://www.youtube.com/channel/UCoSPSd6Or4F_vpjo4SmyoEA
+  class: icon-linkedin
+  title: "LinkedIn Page"
 
-# - name: Mixcloud
-#   url: http://www.mixcloud.com/phlow/
-#   class: icon-cloud
-#   title: "Mixe, was sonst?"
-
-# - name: Phlow YouTube Google+
-#   url: https://plus.google.com/u/0/+Phlow
-#   class: icon-googleplus
-#   title: "YouTube Google+"
-
-# - name: Facebook
-#   url: http://www.facebook.com/
-#   class: icon-facebook
-#   title: ""
-
-# - name: Soundcloud
-#   url: http://soundcloud.com/
-#   class: icon-soundcloud
-#   title: ""
-
-# - name: Instagram
-#   url: http://instagram.com/
-#   class: icon-instagram
-#   title: ""
-
-# - name: Pinterest
-#   url: http://www.pinterest.com/
-#   class: icon-pinterest
-#   title: ""
-
-# - name: Xing
-#   url: https://www.xing.com/profile/
-#   class: icon-xing
-#   title: Xing Profil
+- name: LinkedIn
+  url: https://www.linkedin.com/groups/4772921/
+  class: icon-linkedin
+  title: "LinkedIn Group"


### PR DESCRIPTION
Based on the information from https://github.com/InnerSourceCommons/innersourcecommons.org/issues/110
I added social media information.

I also translated the GitHub title from German to English and
removed the commented ones (we can re-add them later when they are
we have actually have them)

I am not 100% happy with having two LinkedIn icons, but one is for
the page and another one is for the group, but this can be rediscussed.

This is how it looks like:
![image](https://user-images.githubusercontent.com/54676965/75623371-b1465a80-5ba9-11ea-945c-857fb84d58ad.png)
