### PR TITLE
Event: Fixed links to ISC Summit Fall 2019

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -13,7 +13,7 @@
   - title: "EU Summit Spring 2020"
     url: "/events/isc-spring-2020"
   - title: "US Summit Fall 2019"
-    url: "http://www.innersource.events"
+    url: "https://jacobgreen197.wixsite.com/mysite-1"
   - title: "EU Summit Spring 2019"
     url: "/events/isc-spring-2019"
     

--- a/events/index.md
+++ b/events/index.md
@@ -8,7 +8,7 @@ title: 'Upcoming InnerSource Events'
    - InnerSource Commons Summit 10 - Madrid, Spain - April 14-16
 
 ## Prior Events
-* [Commons Summit 9 - Fall 2019](https://www.innersource.events/)
+* [Commons Summit 9 - Fall 2019](https://jacobgreen197.wixsite.com/mysite-1)
    - InnerSource Commons Summit 9 - Baltimore, MD, USA - September 17-19
 * [Commons Summit 8 - Spring 2019](isc-spring-2019)
    - InnerSource Commons Summit 8 - Galway, Ireland - April 9-11


### PR DESCRIPTION
This commit address the comments from https://github.com/InnerSourceCommons/innersourcecommons.org/issues/112

I have fixed the links to ISC Summit Fall 2019 as per the information given
by https://github.com/jacoblyopen.

I left out the suggestion "or we can copy the relevant text over to a new ISC page
(best for long term archival)" but I think this is a valid suggestion for the long
term.

As a short term measure, I archived the link and most important subpage in
web.archive.org, so at least we should have a fallback.