### PR TITLE
Solves Learningpath #119 by adding the links to the articles below the videos.

### DIFF
--- a/resources/learningpath/index.md
+++ b/resources/learningpath/index.md
@@ -9,12 +9,12 @@ Their production was kindly sponsored by PayPal. The Learning Path section intro
 
 Once finished, the first edition of the InnerSource Learning Path will cover the following sections:
 
-1. Introduction
-  * [Introduction] 
-  * [Introduction on O'Reilly Safari] 
-1. [Product Owner on O'Reilly Safari]
-1. [Trusted Committer on O'Reilly Safari]
-1. [Contributor on O'Reilly Safari]
+| O'Reilly | ISC |
+| ------- | ---- |
+| [Introduction on O'Reilly Safari] | [Introduction on ISC][Introduction]  |
+| [Product Owner on O'Reilly Safari] | |
+| [Trusted Committer on O'Reilly Safari] | |
+| [Contributor on O'Reilly Safari] |
 
 The videos are becoming available on YouTube part by part.
 See our channel here: [YouTubeChannel]

--- a/resources/learningpath/index.md
+++ b/resources/learningpath/index.md
@@ -9,10 +9,12 @@ Their production was kindly sponsored by PayPal. The Learning Path section intro
 
 Once finished, the first edition of the InnerSource Learning Path will cover the following sections:
 
-1. [Introduction]
-1. [Product Owner] *(O'Reilly)*
-1. [Trusted Committer] *(O'Reilly)*
-1. Contributor *(coming soon...)*
+1. Introduction
+  * [Introduction] 
+  * [Introduction on O'Reilly Safari] 
+1. [Product Owner on O'Reilly Safari]
+1. [Trusted Committer on O'Reilly Safari]
+1. [Contributor on O'Reilly Safari]
 
 The videos are becoming available on YouTube part by part.
 See our channel here: [YouTubeChannel]
@@ -23,8 +25,11 @@ We invite you to help us finishing the InnerSource Learning Paths. Checkout the 
 
 [InnerSource Commons]: https://www.innersourcecommons.org/
 [#learning-path]: https://paypalflow.slack.com/messages/CARTU4XV2
-[Trusted Committer]: https://learning.oreilly.com/videos/the-trusted-committer/9781492047599
+[Trusted Committer on O'Reilly Safari]: https://learning.oreilly.com/videos/the-trusted-committer/9781492047599
 [Introduction]: ./introduction
-[Product Owner]: https://learning.oreilly.com/videos/innersource-product-owners/9781492046707
+[Introduction on O'Reilly Safari]: https://learning.oreilly.com/videos/introduction-to-innersource/9781492041504 
+
+[Product Owner on O'Reilly Safari]: https://learning.oreilly.com/videos/innersource-product-owners/9781492046707
 [http://bit.ly/inner-source-learning-path]: http://bit.ly/inner-source-learning-path
 [YouTubeChannel]: https://www.youtube.com/channel/UCoSPSd6Or4F_vpjo4SmyoEA
+[Contributor on O'Reilly Safari]: https://learning.oreilly.com/learning-paths/learning-path-the/0636920338833/

--- a/resources/learningpath/introduction.md
+++ b/resources/learningpath/introduction.md
@@ -4,26 +4,34 @@ show_meta: false
 title: 'Learning Path - Introduction'
 ---
 
+## Videos currently under review. They'll be here soon.
+
 ### 01 - Introduction
 <br />
 <iframe width="560" height="315" src="https://www.youtube.com/embed/tP6K5oF2IxQ" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<a href="https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/introduction/01-introduction.asciidoc">View the article (on GitHub)</a>
 
 ### 02 - What problems does InnerSource solve
 <br />
 <iframe width="560" height="315" src="https://www.youtube.com/embed/CxsfR_n7JKI" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<a href="https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/introduction/02-problems-solved.asciidoc">View the article (on GitHub)</a>
 
 ### 03 - How does InnerSource work?
 <br />
 <iframe width="560" height="315" src="https://www.youtube.com/embed/E6VVv9S5aKw" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<a href="https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/introduction/03-how-works.asciidoc">View the article (on GitHub)</a>
 
 ### 04 - What are the benefits of InnerSource?
 <br />
 <iframe width="560" height="315" src="https://www.youtube.com/embed/sPxs0hXVbGM" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<a href="https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/introduction/04-benefits.asciidoc">View the article (on GitHub)</a>
 
 ### 05 - Principles of InnerSource
 <br />
 <iframe width="560" height="315" src="https://www.youtube.com/embed/mgB6MoRlJPQ" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<a href="https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/introduction/05-principles.asciidoc">View the article (on GitHub)</a>
 
 ### 06 - Conclusion
 <br />
 <iframe width="560" height="315" src="https://www.youtube.com/embed/8LErWYnMfeQ" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<a href="https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/introduction/06-conclusion.asciidoc">View the article (on GitHub)</a>


### PR DESCRIPTION
Updates our learning path overview site with the remaining links and adds the article links to our introduction self-hosting.

This addresses https://github.com/InnerSourceCommons/InnerSourceLearningPath/issues/119