### PR TITLE
Added "Board" page and first example for terse notes

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -55,6 +55,8 @@
   dropdown:
   - title: "Contact"
     url: "/contact/"
+  - title: "Board"
+    url: "/board/"
 
 - title: "Wiki"
   url: "/wiki/"

--- a/board/2020-06-10-terse-notes.md
+++ b/board/2020-06-10-terse-notes.md
@@ -16,16 +16,14 @@ title: 'Terse Notes from Board Meeting on 2020-06-10'
 - Danese Cooper (President)
 - Maximilian Capraro
 - Isabel Drost-Fromm
-- Jacob Green
 - Georg Grütter (Vice President)
 - Daniel Izquierdo
 - Russel Rutledge (Secretary)
-- Klaas-Jan Stol
-- Johannes Tigges
 
 #### Directors Absent
 
 - Cedric Williams (Treasurer)
+- Timothy H-J. Yao
 
 #### Members Present
 

--- a/board/2020-06-10-terse-notes.md
+++ b/board/2020-06-10-terse-notes.md
@@ -1,0 +1,38 @@
+---
+layout: page
+show_meta: false
+title: 'Terse Notes from Board Meeting on 2020-06-10'
+---
+
+### Date and Time of Meeting
+
+2020-06-10, 6 p.m - 7 p.m. CEST / 11 a.m. - noon CDT
+
+### Role Call
+
+#### Directors Present
+
+- Silona Bonewald
+- Danese Cooper (President)
+- Maximilian Capraro
+- Isabel Drost-Fromm
+- Jacob Green
+- Georg Grütter (Vice President)
+- Daniel Izquierdo
+- Russel Rutledge (Secretary)
+- Klaas-Jan Stol
+- Johannes Tigges
+
+#### Directors Absent
+
+- Cedric Williams (Treasurer)
+
+#### Members Present
+
+- Jacob Green
+- Klaas-Jan Stol
+- Johannes Tigges
+
+### Votes Taken
+
+none

--- a/board/index.md
+++ b/board/index.md
@@ -1,0 +1,32 @@
+---
+layout: page
+# title: "Board"
+meta_title: "Board of Directors of the InnerSource Commons Foundation"
+subheadline: "Board of Directors of the InnerSource Commons Foundation"
+teaser: "Learn who is on the board and stay up to date on board decisions"
+permalink: "/board/"
+---
+
+* Email: <board@innersourcecommons.org>
+
+The current board of directors of the InnerSource Commons Foundation is 
+comprised of:
+
+| Name | Email |
+|------|-------|
+| Danese Cooper (as President) | |
+| Georg Gruetter (as Vice President | |
+| Russel Rutldege (as Secretary) | |
+| Cedric Williams (as Treasurer) | | 
+| Silona Irene Bonewald | | 
+| Max Capraro | | | 
+| Daniel Izquierdo Cortázar | | 
+| Isabel Drost-Fromm | | 
+| Timothy H-J. Yao | | 
+
+## Public Board Meeting Notes
+
+- [2020-06-10]({{ site.baseurl}}/board/2020-06-10-terse-notes/)
+
+
+

--- a/board/terse-notes-template.md
+++ b/board/terse-notes-template.md
@@ -1,0 +1,34 @@
+---
+layout: page
+show_meta: false
+title: 'Terse Notes from Board Meeting on YYYY-MM-DD'
+---
+
+### Date and Time of Meeting
+
+e. g. 2020-06-10, 6 p.m - 7 p.m. CEST / 11 a.m. - noon CDT
+
+### Role Call
+
+#### Directors Present
+
+- Silona Bonewald
+- Danese Cooper (President)
+- Maximilian Capraro
+- Isabel Drost-Fromm
+- Jacob Green
+- Georg Grütter (Vice President)
+- Daniel Izquierdo
+- Russel Rutledge (Secretary)
+- Klaas-Jan Stol
+- Johannes Tigges
+- Cedric Williams (Treasurer)
+
+#### Directors Absent
+
+
+#### Members Present
+
+### Votes Taken
+
+none

--- a/board/terse-notes-template.md
+++ b/board/terse-notes-template.md
@@ -16,13 +16,11 @@ e. g. 2020-06-10, 6 p.m - 7 p.m. CEST / 11 a.m. - noon CDT
 - Danese Cooper (President)
 - Maximilian Capraro
 - Isabel Drost-Fromm
-- Jacob Green
 - Georg Grütter (Vice President)
 - Daniel Izquierdo
 - Russel Rutledge (Secretary)
-- Klaas-Jan Stol
-- Johannes Tigges
 - Cedric Williams (Treasurer)
+- Timothy H-J. Yao
 
 #### Directors Absent
 


### PR DESCRIPTION
This PR adds the _Board_ page, accessible in the _About_ tab. The board page lists all current directors and links to published terse notes for private board meetings. These notes need to be published [for legal reasons](https://www.501c3.org/importance-of-nonprofit-board-meeting-minutes/). I have also added the notes of the last board meeting as a sample and a template based on that.