### PR TITLE
Adding short(er) link for the newly created ISC 101 document

### DIFF
--- a/pages/innersourcecommons-101.md
+++ b/pages/innersourcecommons-101.md
@@ -1,0 +1,8 @@
+---
+layout: page
+show_meta: false
+title: 'InnerSource Commons 101'
+permalink: "/innersourcecommons-101/"
+redirect_to:
+    - https://docs.google.com/document/d/1VvdgN2b0MAd7wXeNGUFaeYviguS34oBioX0XavNtbyY/edit?usp=sharing
+---


### PR DESCRIPTION
@lenucksi here the short link for the document that the Marketing WG is creating as part of https://github.com/InnerSourceCommons/marketing-wg/issues/18.

Not sure which short link to choose:

- http://innersourcecommons.org/innersourcecommons-101/ (this is what is in this PR)

Or alternatively:

- http://innersourcecommons.org/isc-101
- http://innersourcecommons.org/101 (very fancy but looks like a strange HTTP status code :))