### PR TITLE
Shortening the link to the The InnerSource Commons 101

### DIFF
--- a/pages/isc-101.md
+++ b/pages/isc-101.md
@@ -1,8 +1,8 @@
 ---
 layout: page
 show_meta: false
-title: 'InnerSource Commons 101'
-permalink: "/innersourcecommons-101/"
+title: 'The InnerSource Commons 101'
+permalink: "/isc-101/"
 redirect_to:
     - https://docs.google.com/document/d/1VvdgN2b0MAd7wXeNGUFaeYviguS34oBioX0XavNtbyY/edit?usp=sharing
 ---


### PR DESCRIPTION
Shortening the link to the InnerSource Commons 101

- renaming the file
- shortening the link

For https://github.com/InnerSourceCommons/marketing-wg/issues/18