### PR TITLE
Update isc-fall-2020.md

### DIFF
--- a/events/isc-fall-2020.md
+++ b/events/isc-fall-2020.md
@@ -8,6 +8,14 @@ Welcome to the 11th InnerSource Commons Summit! Thanks to the success of the <a 
 
 We continue to explore new ways to get together and keep advancing in the body of knowledge of InnerSource. Nowadays, particularly in this industry, it is more important than ever to successfully work remotely and across different geographical areas. This online event has this in mind and we hope to learn from each other, what it is working and what it is not.
 
+### Summit News
+
+We are delighted to announce that **Tim O'Reilly** (Founder, CEO, and Chairman of O'Reilly Media) has been confirmed as a keynote speaker for this summit. 
+
+Tim will join **Danese Cooper** (VP of Special Initiatives at NearForm), **James McLeod** (Director of Community at FINOS, the Fintech Open Source Foundation), **Martin Woodward** (Director of Developer Relations at GitHub), and **Silona Bonewald** (Executive Director at IEEE SA Open) in the keynote sessions. 
+
+### About the Event
+
 The summit consists of two days, each a 3.5 hour slot: running from noon East Coast US / 9 am West Coast US / 6pm Europe / 5pm UK & Ireland / 9:30pm Mumbai / midnight Singapore & Bejing (4pm UTC). 
 
 We are a global community, but because our Fall Summit usually takes place in North America, it will take place slightly later than our Spring Summit (traditionally EU). 
@@ -20,9 +28,7 @@ We are hoping to host an online summit later in the year to fit with the timezon
 
 ### Agenda and Speakers
 
-We are deligthed to welcome Danese Cooper (VP of Special Initiatives at NearForm), Martin Woodward (Director of Developer Relations at GitHub), James McLeod (Director of Community at FINOS, the Fintech Open Source Foundation), and Silona Bonewald (Executive Director at IEEE SA Open) as our first confirmed keynote speakers. 
-
-We will be updating this list over the next few weeks as new speakers are confirmed. The full agenda will be available after our CFP closes. Stay tuned!
+We will be updating our agenda over the next few weeks as new speakers are confirmed. The full agenda will be available after our CFP closes. Stay tuned!
 
 ### Call For Presentations
 
@@ -50,23 +56,28 @@ The three key reasons to attend the InnerSource Common Summits are:
 
 ### Keynote Speaker Bios
 
+
+**Silona Bonewald**
+
+Silona Bonewald is the Executive Director of IEEE SA Open. Previously, Silona served as Vice President of Community Architecture at Hyperledger, a global open source collaborative effort hosted by The Linux Foundation, where she integrated leaders in finance, banking, Internet of Things (IoT), supply chains, and manufacturing. Other notable career accomplishments include, while with PayPal, pioneering the InnerSource process; for Siemens AG, creating a cutting-edge and Six Sigma-compliant e-commerce website; and for Ubisoft, creating an international content management system (CMS) architecture.
+
 <img alt="Danese Cooper photo" src="/assets/img/Danese_Cooper.jpg" width="200" align="right"/>
 
 **Danese Cooper**
 
 Danese Cooper is the Chairperson of InnerSource Commons and Vice President of Special Initiatives at NearForm, an Irish tech firm. Previously, she was Head of Open Source software at PayPal, CTO of Wikipedia, Chief Open Source Evangelist for Sun, and Senior Director of Open Source Strategies for Intel. Danese was also the inaugural chairperson of the Node.js Foundation. She concentrates on creating healthy open source communities and has served on the boards of Drupal Association, the Open Source Initiative, the Open Source Hardware Association, and she’s advised Mozilla and the Apache Software Foundation. Danese also runs a successful open source consultancy that counts the Bill & Melinda Gates Foundation, the SETI Institute, Harris, and Numenta as clients. She’s been known to knit through meetings.
 
-**Martin Woodward**
-
-Martin Woodward is the Director of Developer Relations for GitHub. Before that Martin was Executive Director of the .NET Foundation helping drive Microsoft’s move towards open source and was a Principal Group Program Manager of the team building tooling and policy to help support InnerSource communities inside the company.
-
 **James McLeod**
 
 James is the Director of Community at FINOS and wholeheartedly believes the transformation of Financial Services can only be fulfilled if Open Source is embraced under the three pillars of Contribution, Consumption and Community. James has a twenty year career in software engineering having worked for telecommunication startups, the gaming industry, digital streaming platforms and financial services. Prior to joining FINOS James worked at Lloyds Banking Group where he focused on building engineering communities for Lloyds Bank, Halifax, Bank of Scotland, Scottish Widows and other LBG banks. While at Lloyds Banking Group, James also drove the adoption of Inner Source and Open Source partly through the creation of engineering guilds providing in-person and remote educational sessions and large hackathon events. James also spent a number of years consulting on software engineering projects for RBS, NatWest and Barclays.
 
-**Silona Bonewald**
+**Tim O'Reilly**
 
-Silona Bonewald is the Executive Director of IEEE SA Open. Previously, Silona served as Vice President of Community Architecture at Hyperledger, a global open source collaborative effort hosted by The Linux Foundation, where she integrated leaders in finance, banking, Internet of Things (IoT), supply chains, and manufacturing. Other notable career accomplishments include, while with PayPal, pioneering the InnerSource process; for Siemens AG, creating a cutting-edge and Six Sigma-compliant e-commerce website; and for Ubisoft, creating an international content management system (CMS) architecture.
+Tim O’Reilly is the founder, CEO, and Chairman of O'Reilly Media, the company that has been providing the picks and shovels of learning to the Silicon Valley goldrush for the past thirty-five years. The company's online learning and knowledge-on-demand platform at oreilly.com is used by thousands of enterprises and millions of individuals worldwide. O'Reilly has a history of convening conversations that reshape the computer industry. If you've heard the term "open source software", "web 2.0", "the Maker movement","government as a platform", or "the WTF economy", he's had a hand in framing each of those big ideas. Tim is also a partner at early stage venture firm O'Reilly AlphaTech Ventures (OATV), and on the boards of Code for America, PeerJ, Civis Analytics, and PopVox. He is the author of many technical books published by O'Reilly Media, and most recently WTF? What's the Future and Why It's Up to Us (Harper Business, 2017). He is working on a new book about why we need to rethink antitrust in the era of internet-scale platforms.
+
+**Martin Woodward**
+
+Martin Woodward is the Director of Developer Relations for GitHub. Before that Martin was Executive Director of the .NET Foundation helping drive Microsoft’s move towards open source and was a Principal Group Program Manager of the team building tooling and policy to help support InnerSource communities inside the company.
 
 ### Venue
 


### PR DESCRIPTION
Added 'news section' to highlight that Tim O'Reilly is a confirmed keynote speaker, changed order of bios to be alphabetical. Some small other edits.