### PR TITLE
Translate Learning Path navigation

### DIFF
--- a/_data/learning_path.yml
+++ b/_data/learning_path.yml
@@ -4,7 +4,7 @@ en:
   prev: "Previous"
   thanks: "Thank you to this article's contributors!"
 de:
-  home: "Zurück zur Homepages des Learning Path"
+  home: "Zurück zur Homepage des Learning Path"
   next: "Nächstes Kapitel"
   prev: "Vorheriges Kapitel"
   thanks: "Wir danken für die Mitarbeit an diesem Artikel:"

--- a/_data/learning_path.yml
+++ b/_data/learning_path.yml
@@ -1,0 +1,25 @@
+en:
+  home: "Back to Learning Path homepage"
+  next: "Next"
+  prev: "Previous"
+  thanks: "Thank you to this article's contributors!"
+de:
+  home: "Zurück zur Homepages des Learning Path"
+  next: "Nächstes Kapitel"
+  prev: "Vorheriges Kapitel"
+  thanks: "Wir danken für die Mitarbeit an diesem Artikel:"
+it:
+  home: "Torna alla home del Learning Path"
+  next: "Prossimo"
+  prev: "Precedente"
+  thanks: "Grazie ai contributori di questo articolo!"
+ja:
+  home: "Learning Pathホームページに戻る"
+  next: "次へ"
+  prev: "前へ"
+  thanks: "この文書に貢献いただいた方々"
+zh:
+  home: "回到Learning Path主页"
+  next: "下一页"
+  prev: "上一页"
+  thanks: "感谢你对这篇文章的贡献"

--- a/_layouts/learning-path-page.html
+++ b/_layouts/learning-path-page.html
@@ -4,7 +4,7 @@ layout: page
 
 {% assign siblings = site.pages | where: "learning_path_group", page.learning_path_group | where: "learning_path_translation", page.learning_path_translation | sort: "learning_path_position" %}
 
-<p><a href="/resources/learningpath/">Back to Learning Path homepage</a></p>
+<p><a href="/resources/learningpath/">{{ site.data.learning_path[page.learning_path_translation].home | default: site.data.learning_path.en.home }}</a></p>
 
 <table>
   <thead>
@@ -83,14 +83,14 @@ layout: page
 <br />
 <p style="text-align: left">
   {% if prev_index > -1 %}
-    <span style="float: left;"></span><a href="{{ prev.url }}" >Previous</a></span>
+    <span style="float: left;"></span><a href="{{ prev.url }}" >{{ site.data.learning_path[page.learning_path_translation].prev | default: site.data.learning_path.en.prev }}</a></span>
   {% endif %}
   {% if next_index < siblings.size %}
-    <span style="float: right"><a href="{{ next.url }}" >Next</a></span>
+    <span style="float: right"><a href="{{ next.url }}" >{{ site.data.learning_path[page.learning_path_translation].next | default: site.data.learning_path.en.next }}</a></span>
   {% endif %}
 </p>
 
-<h4>Thank you to this article's contributors!</h4>
+<h4>{{ site.data.learning_path[page.learning_path_translation].thanks | default: site.data.learning_path.en.thanks }}</h4>
 <ul>
   {% for contributor in page.contributors %}
     {% if contributor.url %}


### PR DESCRIPTION
Add translations for 'Back to Learning Path homepage', 'Next', 'Previous', 'Thank you to this article's contributors!', defaulting back to English if data is missing.

See https://github.com/InnerSourceCommons/InnerSourceLearningPath/issues/333