### PR TITLE
Fixing link to the book 'Managing InnerSource Projects' by bitergia

### DIFF
--- a/resources/books/index.md
+++ b/resources/books/index.md
@@ -7,4 +7,4 @@ permalink: '/resources/books/'
   * [Getting Started With InnerSource](http://www.oreilly.com/programming/free/getting-started-with-innersource.csp)
   * [Understanding the InnerSource Checklist]({{ site.baseurl }}/checklist/)
   * [Adopting InnerSource - Principles and Case Studies](adoptinginnersource)
-  * [Managing InnerSource Projects](https://legacy.gitbook.com/book/dicortazar/managing-inner-source-projects/details)
+  * [Managing InnerSource Projects](https://dicortazar.gitbook.io/managing-inner-source-projects/)


### PR DESCRIPTION
@dicortazar the old link to the gitbook 'Managing InnerSource Projects' broke. 
I replaced it with another link that I found online. Please confirm if it is correct. 
Cheers :)