### PR TITLE
Add link to latest Summit videos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build.sh
 vendor/
 .bundle/
 .jekyll-cache/
+Gemfile.lock

--- a/_includes/_sidebar.html
+++ b/_includes/_sidebar.html
@@ -1,11 +1,11 @@
 <aside>
     <div class="panel radius">
         <h3><a href="/events/">ISC Events</a></h3>
-        
+
 	<p>
     See you in the 2021 Event Season.
 	</p>
-  <p>Sessions from the InnerSource Commons Fall 2020 Virtual Summit are <a href="https://www.youtube.com/playlist?list=PLCH-i0B0otNQZQt_QzGR9Il_kE4C6cQRy">available on YouTube.</a></p>
+  <p>Sessions from the InnerSource Commons APAC 2020 Online Summit are <a href="https://bit.ly/3moel7B">available on YouTube.</a></p>
 	<p>Also see information on our <a href="/events">past events</a>.</p>
     </div>
     <div class="panel radius">
@@ -13,7 +13,7 @@
         <p>Learn about <a href="https://github.com/InnerSourceCommons/InnerSourcePatterns">InnerSource Patterns</a> by watching the replay of the <em>Implementing InnerSource Patterns: Solve Organizational Problems by Leveraging Community Contributions</em> webinar from Thursday, June 1, 2017.
         </p>
     </div>
-	
+
 	<div class="panel radius">
         	<h3><a href="/resources/learningpath/">ISC Learning Path</a></h3>
        		<p>The InnerSource Commons Learning Path community is focused on creating a set of resources explaining and teaching various aspects of InnerSource. <a href="/resources/learningpath/">Check out</a> this curated set of videos and articles that have been proven to lead to successful InnerSource practices.
@@ -32,7 +32,7 @@
         Many organizations care about InnerSource - some are already deeply involved, some just considering starting. Here are the results from <a href="/assets/files/InnerSourceCommonsSurvey2016.pdf">our last InnerSource Survey in 2016</a>. We are currently working on an updated survey, please join us if you would like to be involved.
       </p>
     </div>
-    
+
   <div class="border-dotted radius b30">
     <p class="text-left">
       Connect with the community

--- a/_includes/_sidebar.html
+++ b/_includes/_sidebar.html
@@ -1,37 +1,38 @@
 <aside>
-    <div class="panel radius">
-        <h3><a href="/events/">ISC Events</a></h3>
+  <div class="panel radius">
+    <h3><a href="/events/">ISC Events</a></h3>
+  	<p>See you in the 2021 Event Season.</p>
+    <p>Sessions from the InnerSource Commons APAC 2020 Online Summit are <a href="https://bit.ly/3moel7B">available on YouTube.</a></p>
+    <p>Also see information on our <a href="/events">past events</a>.</p>
+  </div>
 
-	<p>
-    See you in the 2021 Event Season.
-	</p>
-  <p>Sessions from the InnerSource Commons APAC 2020 Online Summit are <a href="https://bit.ly/3moel7B">available on YouTube.</a></p>
-	<p>Also see information on our <a href="/events">past events</a>.</p>
-    </div>
-    <div class="panel radius">
-        <h3><a href="http://www.oreilly.com/pub/e/3884">O'Reilly Webinar</a></h3>
-        <p>Learn about <a href="https://github.com/InnerSourceCommons/InnerSourcePatterns">InnerSource Patterns</a> by watching the replay of the <em>Implementing InnerSource Patterns: Solve Organizational Problems by Leveraging Community Contributions</em> webinar from Thursday, June 1, 2017.
-        </p>
-    </div>
+  <div class="panel radius">
+    <h3><a href="http://www.oreilly.com/pub/e/3884">O'Reilly Webinar</a></h3>
+    <p>
+      Learn about <a href="https://github.com/InnerSourceCommons/InnerSourcePatterns">InnerSource Patterns</a> by watching the replay of the <em>Implementing InnerSource Patterns: Solve Organizational Problems by Leveraging Community Contributions</em> webinar from Thursday, June 1, 2017.
+    </p>
+  </div>
 
 	<div class="panel radius">
-        	<h3><a href="/resources/learningpath/">ISC Learning Path</a></h3>
-       		<p>The InnerSource Commons Learning Path community is focused on creating a set of resources explaining and teaching various aspects of InnerSource. <a href="/resources/learningpath/">Check out</a> this curated set of videos and articles that have been proven to lead to successful InnerSource practices.
+  	<h3><a href="/resources/learningpath/">ISC Learning Path</a></h3>
+		<p>
+      The InnerSource Commons Learning Path community is focused on creating a set of resources explaining and teaching various aspects of InnerSource. <a href="/resources/learningpath/">Check out</a> this curated set of videos and articles that have been proven to lead to successful InnerSource practices.
 		</p>
 	</div>
 
 	<div class="panel radius">
-        	<h3><a href="https://github.com/InnerSourceCommons/InnerSourcePatterns">ISC Patterns</a></h3>
-       		<p>Learn about <a href="https://github.com/InnerSourceCommons/InnerSourcePatterns">InnerSource Patterns</a> by exploring the best practices codified by the InnerSource Commons community.
+  	<h3><a href="https://github.com/InnerSourceCommons/InnerSourcePatterns">ISC Patterns</a></h3>
+		<p>
+      Learn about <a href="https://github.com/InnerSourceCommons/InnerSourcePatterns">InnerSource Patterns</a> by exploring the best practices codified by the InnerSource Commons community.
 		</p>
 	</div>
 
-    <div class="panel radius">
-      <h3><a href="/assets/files/InnerSourceCommonsSurvey2016.pdf">InnerSource Survey</a></h3>
-      <p>
-        Many organizations care about InnerSource - some are already deeply involved, some just considering starting. Here are the results from <a href="/assets/files/InnerSourceCommonsSurvey2016.pdf">our last InnerSource Survey in 2016</a>. We are currently working on an updated survey, please join us if you would like to be involved.
-      </p>
-    </div>
+  <div class="panel radius">
+    <h3><a href="/assets/files/InnerSourceCommonsSurvey2016.pdf">InnerSource Survey</a></h3>
+    <p>
+      Many organizations care about InnerSource - some are already deeply involved, some just considering starting. Here are the results from <a href="/assets/files/InnerSourceCommonsSurvey2016.pdf">our last InnerSource Survey in 2016</a>. We are currently working on an updated survey, please join us if you would like to be involved.
+    </p>
+  </div>
 
   <div class="border-dotted radius b30">
     <p class="text-left">

--- a/board/2020-11-18-terse-notes.md
+++ b/board/2020-11-18-terse-notes.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 show_meta: false
-title: 'Terse Notes from Board Meeting on 2020-11-18`
+title: 'Terse Notes from Board Meeting on 2020-11-18'
 ---
 
 ### Date and Time of Meeting

--- a/events/index.md
+++ b/events/index.md
@@ -9,12 +9,12 @@ title: 'InnerSource Commons Events'
 
 ## Prior Events
 
-* [Commons Summit 12 - APAC 2020](http://innersourcecommons.org/events/isc-apac-dec-2020/)
-   - InnerSource Commons Summit 12 - Virtual - December 2-3 2020
+* [Commons Summit 12 - APAC 2020](isc-apac-dec-2020)
+   - InnerSource Commons Summit 12 - Virtual - December 2-3 2020 - [Session recordings](https://bit.ly/3moel7B)
 * [Commons Summit 11 - Fall 2020](isc-fall-2020)
-   - InnerSource Commons Summit 11 - Virtual - September 15-16 2020 – <a href="https://bit.ly/3iii04O">Session recordings</a> 
+   - InnerSource Commons Summit 11 - Virtual - September 15-16 2020 – [Session recordings](https://bit.ly/3iii04O)
 * [Commons Summit 10 - Spring 2020](isc-spring-2020)
-   - InnerSource Commons Summit 10 - Online - April 14-16 – <a href="https://www.youtube.com/playlist?list=PLCH-i0B0otNQeYBH5QvNRBDA3CMrS9lL9">Session recordings</a>
+   - InnerSource Commons Summit 10 - Online - April 14-16 – [Session recordings](https://www.youtube.com/playlist?list=PLCH-i0B0otNQeYBH5QvNRBDA3CMrS9lL9)
 * [Commons Summit 9 - Fall 2019](https://jacobgreen197.wixsite.com/mysite-1)
    - InnerSource Commons Summit 9 - Baltimore, MD, USA - September 17-19
 * [InnerSource Day at OSCON 2019](https://conferences.oreilly.com/oscon/oscon-or-2019/public/schedule/full/innersource-day) (not organized by the InnerSource Commons)
@@ -43,4 +43,5 @@ title: 'InnerSource Commons Events'
     - InnerSource Commons Summit 1 - London, England, April 21-22 2016
 
 ## Help us inform the ISC members!
+
 Know of additional InnerSource events? Send us a [pull request](https://github.com/InnerSourceCommons/innersourcecommons.org/pulls) or open an [issue](https://github.com/InnerSourceCommons/innersourcecommons.org/issues).

--- a/events/index.md
+++ b/events/index.md
@@ -10,7 +10,7 @@ title: 'InnerSource Commons Events'
 ## Prior Events
 
 * [Commons Summit 12 - APAC 2020](isc-apac-dec-2020)
-   - InnerSource Commons Summit 12 - Virtual - December 2-3 2020 - [Session recordings](https://bit.ly/3moel7B)
+   - InnerSource Commons Summit 12 - Virtual - December 2-3 2020 - [Session recordings](https://www.youtube.com/playlist?list=PLCH-i0B0otNSA4KltJHgcQB6450VI-8pG)
 * [Commons Summit 11 - Fall 2020](isc-fall-2020)
    - InnerSource Commons Summit 11 - Virtual - September 15-16 2020 – [Session recordings](https://bit.ly/3iii04O)
 * [Commons Summit 10 - Spring 2020](isc-spring-2020)

--- a/events/index.md
+++ b/events/index.md
@@ -12,7 +12,7 @@ title: 'InnerSource Commons Events'
 * [Commons Summit 12 - APAC 2020](isc-apac-dec-2020)
    - InnerSource Commons Summit 12 - Virtual - December 2-3 2020 - [Session recordings](https://www.youtube.com/playlist?list=PLCH-i0B0otNSA4KltJHgcQB6450VI-8pG)
 * [Commons Summit 11 - Fall 2020](isc-fall-2020)
-   - InnerSource Commons Summit 11 - Virtual - September 15-16 2020 – [Session recordings](https://bit.ly/3iii04O)
+   - InnerSource Commons Summit 11 - Virtual - September 15-16 2020 – [Session recordings](https://www.youtube.com/playlist?list=PLCH-i0B0otNQZQt_QzGR9Il_kE4C6cQRy)
 * [Commons Summit 10 - Spring 2020](isc-spring-2020)
    - InnerSource Commons Summit 10 - Online - April 14-16 – [Session recordings](https://www.youtube.com/playlist?list=PLCH-i0B0otNQeYBH5QvNRBDA3CMrS9lL9)
 * [Commons Summit 9 - Fall 2019](https://jacobgreen197.wixsite.com/mysite-1)


### PR DESCRIPTION
Functional changes:

- Add links to Summit video recordings to sidebar, and also to list of events. (check only https://github.com/InnerSourceCommons/innersourcecommons.org/commit/a7184eabbfa6588fc01dbfb728723da1dbf938cf to see those)
- fix parsing error in latest board notes

Non-functional changes:

-  changed links on events page to use markdown syntax rather than HTML
- fix code indentation of the HTML in the sidebar
- add `Gemfile.lock` to ignored files