### PR TITLE
Fix build error

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -18,7 +18,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gems-
 
-      - uses: helaili/jekyll-action@56f7087
+      - uses: helaili/jekyll-action@56f7087e21a9a8a069e5896c5caf160f1ff361c5
         env:
           #JEKYLL_PAT: ${{ secrets.JEKYLL_PAT }}
           JEKYLL_PAT: ${{ github.actor }}:${{ github.token }}


### PR DESCRIPTION
In our [action logs](https://github.com/InnerSourceCommons/innersourcecommons.org/actions/runs/614986117):

 ```Unable to resolve action `helaili/jekyll-action@56f7087`, the provided ref `56f7087` is the shortened version of a commit SHA, which is not supported. Please use the full commit SHA `56f7087e21a9a8a069e5896c5caf160f1ff361c5` instead.```